### PR TITLE
Fix line length linting violations in calculate_ai and ttest_all

### DIFF
--- a/R/calculate_ai.R
+++ b/R/calculate_ai.R
@@ -137,7 +137,8 @@ calculate_ai <-
         )
 
       if (isTRUE(only_max)) {
-        # Keep only comparisons against the group with the highest selection ratio
+        # Keep only comparisons against the group with the highest
+        # selection ratio
         max_sr_groups <-
           df_sr |>
           dplyr::group_by(.data$Grouping) |>

--- a/R/ttest_all.R
+++ b/R/ttest_all.R
@@ -50,7 +50,9 @@ ttest_all <-
                         df$Grouped <- .create_percentile_groups(df, x, z)
 
                         # Create formula safely using rlang::new_formula
-                        formula <- rlang::new_formula(as.name(y), quote(Grouped))
+                        formula <- rlang::new_formula(
+                          as.name(y), quote(Grouped)
+                        )
 
                         # Calculate Cohen's D
                         cd <- effsize::cohen.d(formula, data = df)
@@ -113,7 +115,17 @@ ttest_all <-
       tidyr::drop_na("estimate") |>
       dplyr::mutate(sig = .data$p.value < .05) |>
       dplyr::mutate(dplyr::across(
-        dplyr::any_of(c("estimate", "estimate1", "estimate2", "statistic", "p.value", "parameter", "conf.low", "conf.high", "Cutoff.Num")),
+        dplyr::any_of(c(
+          "estimate",
+          "estimate1",
+          "estimate2",
+          "statistic",
+          "p.value",
+          "parameter",
+          "conf.low",
+          "conf.high",
+          "Cutoff.Num"
+        )),
         \(x) round(x, 6)
       )) |>
       dplyr::distinct(


### PR DESCRIPTION
Fix line length linting violations in calculate_ai and ttest_all

This commit resolves `line_length_linter` errors (lines > 80 characters) reported by `lintr::lint_package()` and failing in the `lint-project` workflow. It wraps comments and code blocks in `R/calculate_ai.R` and `R/ttest_all.R`.

---
*PR created automatically by Jules for task [12336071295966215312](https://jules.google.com/task/12336071295966215312) started by @samuelkaminsky*